### PR TITLE
Add dark theme toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,6 +38,7 @@
         </ul>
       </div>
       <!-- /menu -->
+      <button id="theme-toggle" class="theme-toggle" aria-label="Alternar tema">🌙</button>
       <div class="toggle icon-menu"></div>
       <div class="toggle icon-close"></div>
     </nav>

--- a/index.html
+++ b/index.html
@@ -38,7 +38,9 @@
         </ul>
       </div>
       <!-- /menu -->
-      <button id="theme-toggle" class="theme-toggle" aria-label="Alternar tema">🌙</button>
+      <button id="theme-toggle" class="theme-toggle" aria-label="Alternar tema">
+        <!-- icon defined in main.js -->
+      </button>
       <div class="toggle icon-menu"></div>
       <div class="toggle icon-close"></div>
     </nav>
@@ -177,6 +179,10 @@
           </p>
           <a href="https://instagram.com/aikyostore/"
             class="button" target="_blank"><i class="icon-instagram"></i> Entrar em contato</a>
+          <button id="share-site" class="button share-button" type="button" aria-label="Compartilhar site">
+            <!-- icon defined in main.js -->
+            Compartilhar
+          </button>
         </div>
 
         <div class="links">

--- a/main.js
+++ b/main.js
@@ -113,3 +113,20 @@ const yearSpan = document.getElementById('current-year')
 if (yearSpan) {
   yearSpan.textContent = new Date().getFullYear()
 }
+
+/* Theme toggle */
+const themeButton = document.getElementById('theme-toggle')
+if (themeButton) {
+  const savedTheme = localStorage.getItem('aikyo-theme')
+  if (savedTheme === 'dark') {
+    document.body.classList.add('dark-theme')
+    themeButton.textContent = '☀️'
+  }
+
+  themeButton.addEventListener('click', () => {
+    document.body.classList.toggle('dark-theme')
+    const isDark = document.body.classList.contains('dark-theme')
+    themeButton.textContent = isDark ? '☀️' : '🌙'
+    localStorage.setItem('aikyo-theme', isDark ? 'dark' : 'light')
+  })
+}

--- a/main.js
+++ b/main.js
@@ -117,16 +117,49 @@ if (yearSpan) {
 /* Theme toggle */
 const themeButton = document.getElementById('theme-toggle')
 if (themeButton) {
+  const sunIcon =
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.25a.75.75 0 0 1 .75.75v2.25a.75.75 0 0 1-1.5 0V3a.75.75 0 0 1 .75-.75ZM7.5 12a4.5 4.5 0 1 1 9 0 4.5 4.5 0 0 1-9 0ZM18.894 6.166a.75.75 0 0 0-1.06-1.06l-1.591 1.59a.75.75 0 1 0 1.06 1.061l1.591-1.59ZM21.75 12a.75.75 0 0 1-.75.75h-2.25a.75.75 0 0 1 0-1.5H21a.75.75 0 0 1 .75.75ZM17.834 18.894a.75.75 0 0 0 1.06-1.06l-1.59-1.591a.75.75 0 1 0-1.061 1.06l1.59 1.591ZM12 18a.75.75 0 0 1 .75.75V21a.75.75 0 0 1-1.5 0v-2.25A.75.75 0 0 1 12 18ZM7.758 17.303a.75.75 0 0 0-1.061-1.06l-1.591 1.59a.75.75 0 0 0 1.06 1.061l1.591-1.59ZM6 12a.75.75 0 0 1-.75.75H3a.75.75 0 0 1 0-1.5h2.25A.75.75 0 0 1 6 12ZM6.697 7.757a.75.75 0 0 0 1.06-1.06l-1.59-1.591a.75.75 0 0 0-1.061 1.06l1.59 1.591Z"/></svg>'
+  const moonIcon =
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path fill-rule="evenodd" d="M9.528 1.718a.75.75 0 0 1 .162.819A8.97 8.97 0 0 0 9 6a9 9 0 0 0 9 9 8.97 8.97 0 0 0 3.463-.69.75.75 0 0 1 .981.98 10.503 10.503 0 0 1-9.694 6.46c-5.799 0-10.5-4.7-10.5-10.5 0-4.368 2.667-8.112 6.46-9.694a.75.75 0 0 1 .818.162Z" clip-rule="evenodd"/></svg>'
+
   const savedTheme = localStorage.getItem('aikyo-theme')
   if (savedTheme === 'dark') {
     document.body.classList.add('dark-theme')
-    themeButton.textContent = '☀️'
+    themeButton.innerHTML = sunIcon
+  } else {
+    themeButton.innerHTML = moonIcon
   }
 
   themeButton.addEventListener('click', () => {
     document.body.classList.toggle('dark-theme')
     const isDark = document.body.classList.contains('dark-theme')
-    themeButton.textContent = isDark ? '☀️' : '🌙'
+    themeButton.innerHTML = isDark ? sunIcon : moonIcon
     localStorage.setItem('aikyo-theme', isDark ? 'dark' : 'light')
+  })
+}
+
+/* Share site button */
+const shareBtn = document.getElementById('share-site')
+if (shareBtn) {
+  const shareIcon =
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path fill-rule="evenodd" d="M15.75 4.5a3 3 0 1 1 .825 2.066l-8.421 4.679a3.002 3.002 0 0 1 0 1.51l8.421 4.679a3 3 0 1 1-.729 1.31l-8.421-4.678a3 3 0 1 1 0-4.132l8.421-4.679a3 3 0 0 1-.096-.755Z" clip-rule="evenodd"/></svg>'
+  shareBtn.insertAdjacentHTML('afterbegin', shareIcon)
+
+  shareBtn.addEventListener('click', async () => {
+    const shareData = {
+      title: document.title,
+      text: 'Confira a AikyoStore',
+      url: window.location.href
+    }
+    try {
+      if (navigator.share) {
+        await navigator.share(shareData)
+      } else {
+        await navigator.clipboard.writeText(shareData.url)
+        alert('Link copiado para a área de transferência!')
+      }
+    } catch (err) {
+      console.error('Erro ao compartilhar', err)
+    }
   })
 }

--- a/style.css
+++ b/style.css
@@ -386,6 +386,16 @@ nav.show div.icon-close {
   margin-right: 1.5rem;
 }
 
+.text a {
+  color: var(--base-color);
+  border-bottom: 1px solid var(--base-color);
+  transition: color 0.2s;
+}
+
+.text a:hover {
+  color: var(--base-color-alt);
+}
+
 /*====  SERVICES ============================ */
 .cards.grid {
   gap: 1.5rem;
@@ -396,6 +406,7 @@ nav.show div.icon-close {
   box-shadow: 0px 0px 12px rgba(0, 0, 0, 0.08);
   border-bottom: 0.25rem solid var(--base-color);
   border-radius: 0.25rem 0.25rem 0 0;
+  background: var(--text-color-light);
   text-align: center;
 }
 
@@ -492,6 +503,16 @@ nav.show div.icon-close {
 #contact ul li i {
   font-size: 1.5rem;
   margin-right: 0.625rem;
+}
+
+.share-button {
+  margin-top: 1rem;
+}
+
+.share-button svg {
+  width: 1.25rem;
+  height: 1.25rem;
+  margin-right: 0.5rem;
 }
 
 #contact ul.grid {

--- a/style.css
+++ b/style.css
@@ -32,6 +32,7 @@ img {
   --text-color: hsl(0 0% 46%);
   --text-color-light: hsl(0 0% 98%);
   --body-color: hsl(0 0% 98%);
+  --header-border-color: #e4e4e4;
 
   /* fonts */
   --title-font-size: 1.875rem;
@@ -40,6 +41,13 @@ img {
   --title-font: 'Poppins', sans-serif;
   --title-fontkinkee: 'KINKEE', kinkee;
   --body-font: 'DM Sans', sans-serif;
+}
+
+body.dark-theme {
+  --title-color: hsl(var(--hue) 41% 90%);
+  --text-color: hsl(0 0% 88%);
+  --body-color: hsl(0 0% 12%);
+  --header-border-color: #444444;
 }
 
 /*===  BASE ============================ */
@@ -132,7 +140,7 @@ body {
 }
 
 #header {
-  border-bottom: 1px solid #e4e4e4;
+  border-bottom: 1px solid var(--header-border-color);
   margin-bottom: 2rem;
   display: flex;
 
@@ -262,6 +270,19 @@ nav.show ul.grid {
   cursor: pointer;
 }
 
+.theme-toggle {
+  font-size: 1.5rem;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--title-color);
+  margin-left: 1rem;
+}
+
+.theme-toggle:hover {
+  color: var(--base-color);
+}
+
 nav .icon-close {
   visibility: hidden;
   opacity: 0;
@@ -329,7 +350,7 @@ nav.show div.icon-close {
 
 /*====  ABOUT ============================ */
 #about {
-  background: white;
+  background: var(--body-color);
 }
 
 #about .container {
@@ -392,7 +413,7 @@ nav.show div.icon-close {
 
 /*====  TESTIMONIALS ============================ */
 #testimonials {
-  background: white;
+  background: var(--body-color);
 }
 
 #testimonials .container {


### PR DESCRIPTION
## Summary
- allow toggling between light and dark theme
- store theme preference in localStorage

## Testing
- `tidy -errors index.html`


------
https://chatgpt.com/codex/tasks/task_e_683fcdc65d0883328ea9aa22d272978b