### PR TITLE
Add dark mode toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,6 +21,8 @@
   <link
     href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;700&family=Poppins:wght@400;500;700&display=swap"
     rel="stylesheet" />
+  <!-- Material Icons for theme toggle -->
+  <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" />
   <link rel="shortcut icon" href="img/favicon/android-chrome-384x384.png" />
 </head>
 
@@ -207,6 +209,9 @@
   </footer>
 
   <a href="#home" class="back-to-top"><i class="icon-arrow-up"></i></a>
+  <button id="theme-toggle" class="theme-toggle" aria-label="Alternar tema">
+    <span class="material-icons">dark_mode</span>
+  </button>
 
   <!-- swiper -->
   <script src="https://unpkg.com/swiper/swiper-bundle.min.js"></script>

--- a/main.js
+++ b/main.js
@@ -113,3 +113,17 @@ const yearSpan = document.getElementById('current-year')
 if (yearSpan) {
   yearSpan.textContent = new Date().getFullYear()
 }
+
+/* Theme toggle */
+const themeButton = document.getElementById('theme-toggle')
+if (themeButton) {
+  themeButton.addEventListener('click', () => {
+    document.body.classList.toggle('dark')
+    const icon = themeButton.querySelector('span')
+    if (document.body.classList.contains('dark')) {
+      icon.textContent = 'light_mode'
+    } else {
+      icon.textContent = 'dark_mode'
+    }
+  })
+}

--- a/style.css
+++ b/style.css
@@ -383,6 +383,9 @@ nav.show div.icon-close {
   border-bottom: 0.25rem solid var(--base-color);
   border-radius: 0.25rem 0.25rem 0 0;
   text-align: center;
+
+  /* keep text colors consistent regardless of theme */
+  color: hsl(0 0% 46%);
 }
 
 .card i {
@@ -395,6 +398,7 @@ nav.show div.icon-close {
 .card .title {
   font-size: 1.5rem;
   margin-bottom: 0.75rem;
+  color: hsl(var(--hue) 41% 10%);
 }
 
 /*====  TESTIMONIALS ============================ */

--- a/style.css
+++ b/style.css
@@ -54,6 +54,12 @@ body {
   -webkit-font-smoothing: antialiased;
 }
 
+body.dark {
+  --title-color: hsl(var(--hue) 41% 90%);
+  --text-color: hsl(0 0% 80%);
+  --body-color: #121212;
+}
+
 .title {
   font: 700 var(--title-font-size) var(--title-font);
   color: var(--title-color);
@@ -329,7 +335,7 @@ nav.show div.icon-close {
 
 /*====  ABOUT ============================ */
 #about {
-  background: white;
+  background: var(--body-color);
 }
 
 #about .container {
@@ -371,6 +377,7 @@ nav.show div.icon-close {
 }
 
 .card {
+  background: white;
   padding: 3.625rem 2rem;
   box-shadow: 0px 0px 12px rgba(0, 0, 0, 0.08);
   border-bottom: 0.25rem solid var(--base-color);
@@ -392,7 +399,7 @@ nav.show div.icon-close {
 
 /*====  TESTIMONIALS ============================ */
 #testimonials {
-  background: white;
+  background: var(--body-color);
 }
 
 #testimonials .container {
@@ -550,6 +557,25 @@ footer .social a:hover {
   visibility: visible;
   opacity: 1;
   transform: translateY(0);
+}
+
+/* Theme toggle button */
+.theme-toggle {
+  background: var(--base-color);
+  color: var(--text-color-light);
+
+  position: fixed;
+  right: 1rem;
+  bottom: 4rem;
+
+  padding: 0.5rem;
+  clip-path: circle();
+
+  font-size: 1.5rem;
+  line-height: 0;
+
+  border: none;
+  cursor: pointer;
 }
 
 /*========= MEDIA QUERIES =========*/


### PR DESCRIPTION
## Summary
- enable Material Icons
- add dark/light theme toggle button
- style toggle and keep cards white
- adjust sections to use theme background
- update JS for theme switching

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68405b18cbe0833286b4c4426f698d11